### PR TITLE
feat/mk1_support

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.10
+          python-version: [3.9, "3.10", "3.11"]
       - name: Install Build Tools
         run: |
           python -m pip install build wheel

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Install Build Tools
         run: |
           python -m pip install build wheel

--- a/ovos_i2c_detection/__init__.py
+++ b/ovos_i2c_detection/__init__.py
@@ -1,5 +1,6 @@
 import subprocess
-
+import serial
+from time import sleep
 
 def is_texas_tas5806():
     cmd = 'i2cdetect -y -a 1 0x2f 0x2f | egrep "(2f|UU)" | awk \'{print $2}\''
@@ -53,3 +54,19 @@ def is_adafruit_amp():
     if out == b"4b" or out == b"UU":
         return True
     return False
+
+def is_mark_1():
+    if is_wm8960():
+        try:
+            ser = serial.Serial("/dev/serial0", 9600, timeout=3)
+            ser.write(b'system.version')
+            while True:
+                is_mk1 = ser.readline().decode().rstrip()
+                if is_mk1 and "Command" in is_mk1:
+                    # This is a Mark 1
+                    return True
+                break
+            return False
+        except:
+            return False
+        

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyserial

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,15 @@ def get_version():
         version += f"post{post}"
     return version
 
+def required(requirements_file):
+    """ Read requirements file and remove comments and empty lines. """
+    with open(os.path.join(BASEDIR, requirements_file), 'r') as f:
+        requirements = f.read().splitlines()
+        if 'MYCROFT_LOOSE_REQUIREMENTS' in os.environ:
+            print('USING LOOSE REQUIREMENTS!')
+            requirements = [r.replace('==', '>=').replace('~=', '>=') for r in requirements]
+        return [pkg for pkg in requirements
+                if pkg.strip() and not pkg.startswith("#")
 
 with open("README.md", "r") as f:
     long_description = f.read()
@@ -46,5 +55,6 @@ setup(
     description='i2c detection for some devices',
     long_description=long_description,
     long_description_content_type="text/markdown",
+    install_requires=required("requirements/requirements.txt"),
     packages=['ovos_i2c_detection'],
 )


### PR DESCRIPTION
Adds support for a Mark 1 device.

This does not setup the sound, just verifies that a Mark 1 is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added device detection for Mark 1 hardware.
	- Implemented serial communication check for specific device identification.

- **Dependencies**
	- Added `pyserial` library for serial communication support.

- **Improvements**
	- Enhanced setup configuration to handle requirements file processing more flexibly.
	- Updated Python version in build tests to 3.10 for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->